### PR TITLE
[Minor] Updated naming accross site to use Apache Livy (Incubating)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Before opening a pull request, you can preview your contributions by running fro
 
 ## Publishing to live site
 
-Livy is using [gitpubsub](http://www.apache.org/dev/gitpubsub.html) for publishing the website,
+Apache Livy (Incubating) is using [gitpubsub](http://www.apache.org/dev/gitpubsub.html) for publishing the website,
 and the live website content is stored in the asf-site git branch.
 
 To publish new contents to the website, commit your changes to master, and use the 'publish.sh' shell script.

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -15,7 +15,7 @@
 #
 # Apache Project configurations
 #
-name: Apache Livy
+name: Apache Livy (Incubating)
 short_name: Livy
 unix_name: livy
 incubator_name: incubator-livy

--- a/site/community.md
+++ b/site/community.md
@@ -74,7 +74,7 @@ Enhancement requests for new features are also welcome. The more concrete and ra
 Once you find an issue that you would like to work on, if no-one is working on it, assign it to yourself (only if you
 intend to work on it shortly though). Except for the very smallest items, it’s a very good idea to discuss your intended
 approach either on the issue's JIRA or on the dev mailing list. You are more likely to have your patch reviewed and
-committed if you’ve already got buy-in from the livy community before you start.
+committed if you’ve already got buy-in from the Livy community before you start.
 
 #### Submitting a Fix
 

--- a/site/download.md
+++ b/site/download.md
@@ -30,7 +30,7 @@ limitations under the License.
 
 ### Source releases
 
-There is no official release of Apache Livy yet, try checking out the [GitHub repo](https://github.com/apache/{{ site.data.project.incubator_name }})
+There is no official release of Apache Livy (Incubating) yet, try checking out the [GitHub repo](https://github.com/apache/{{ site.data.project.incubator_name }})
 
 <!-- COMMENTED OUT UNTIL FIRST RELEASE
 Release          | Date       | Commit   | Download

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <br/><br/>
 
-## Getting Started
+## Getting Started with Apache Livy (Incubating)
 
 ### 1. Install Livy
 Download Livy packages from [here]({{ site.baseurl }}/download).

--- a/site/index.md
+++ b/site/index.md
@@ -25,23 +25,23 @@ limitations under the License.
 {% include JB/setup %}
 
 #### *Submit Jobs from Anywhere*
-> Livy enables programmatic, fault-tolerant, multi-tenant submission of Spark jobs from web/mobile apps (no Spark
+> Apache Livy (Incubating) enables programmatic, fault-tolerant, multi-tenant submission of Spark jobs from web/mobile apps (no Spark
 client needed). So, multiple users can interact with your Spark cluster concurrently and reliably.
 
 #### *Use Interactive Scala or Python*
-> Livy speaks either Scala or Python, so clients can communicate with your Spark cluster via either language remotely.
+> Apache Livy (Incubating) speaks either Scala or Python, so clients can communicate with your Spark cluster via either language remotely.
 Also, batch job submissions can be done in Scala, Java, or Python.
 
 #### *No Code Changes Needed*
-> Don't worry, no changes to existing programs are needed to use Livy. Just build Livy with Maven, deploy the
+> Don't worry, no changes to existing programs are needed to use Apache Livy (Incubating). Just build Livy with Maven, deploy the
 configuration file to your Spark cluster, and you're off! Check out [Get Started]({{ site.baseurl }}/get-started) to
 get going.
 
-### What is Apache Livy?
+### What is Apache Livy (Incubating)?
 
-Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface. It enables easy
+Apache Livy (Incubating) is a service that enables easy interaction with a Spark cluster over a REST interface. It enables easy
 submission of Spark jobs or snippets of Spark code, synchronous or asynchronous result retrieval, as well as Spark
-Context management, all via a simple REST interface or a RPC client library. Apache Livy also simplifies the
+Context management, all via a simple REST interface or a RPC client library. Apache Livy (Incubating) also simplifies the
 interaction between Spark from application servers, thus enabling the use of Spark for interactive web/mobile
 applications. Additional features include:
 


### PR DESCRIPTION
Naming across the site is now either Apache Livy (Incubating) or Livy depending on situation