### PR TITLE
Improvements to getting started and community pages

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -31,8 +31,8 @@ Every volunteer project obtains its strength from the people involved in it. We 
 
 You can:
 
-* Use our project and provide a feedback.
-* Provide us with the use-cases.
+* Use our project and provide feedback.
+* Provide us with use cases.
 * Report bugs and submit patches.
 * Contribute code, javadocs, documentation.
 
@@ -54,13 +54,13 @@ Found bug? Enter an issue in the [Issue Tracker](https://issues.apache.org/jira/
 Before submitting an issue, please:
 
 * Verify that the bug does in fact exist.
-* Search the issue tracker to verify there is no existing issue reporting the bug you've found.
+* Search the issue tracker to verify there are no existing issue reporting the bug you've found.
 * Consider tracking down the bug yourself in the Livy source code and submitting a patch along with your bug report. This is a great time saver for the Livy developers and helps ensure the bug will be fixed quickly.
 
 
 #### Feature Requests
 
-Enhancement requests for new features are also welcome. The more concrete and rationale the request is, the greater the chance it will incorporated into future releases.
+Enhancement requests for new features are also welcome. The more concrete and rational the request is, the greater the chance it will be incorporated into future releases.
 
 
   [https://issues.apache.org/jira/browse/{{ site.data.project.jira }}](https://issues.apache.org/jira/browse/{{ site.data.project.jira }})
@@ -69,7 +69,7 @@ Enhancement requests for new features are also welcome. The more concrete and ra
 
 #### Finding an Issue
 
-Once you find an issue that you would like to work on, if no-one is working on it, assign it to yourself (only if you
+Once you find an issue that you would like to work on, if no one is working on it, assign it to yourself (only if you
 intend to work on it shortly though). Except for the very smallest items, it’s a very good idea to discuss your intended
 approach either on the issue's JIRA or on the dev mailing list. You are more likely to have your patch reviewed and
 committed if you’ve already got buy-in from the livy community before you start.
@@ -81,13 +81,13 @@ As you are writing your patch, please keep the following things in mind:
 1. Include tests with your patch. If your patch does not include tests, it will not be accepted. If you are
 unsure how to write tests for a particular component, please ask on the dev mailing list for guidance.
 
-2. Keep your patch narrowly targeted to the problem described by the JIRA. It is important to we maintain
+2. Keep your patch narrowly targeted to the problem described by the JIRA. It is important that we maintain
 discipline about the scope of each patch. In general, if you find a bug while working on a specific feature, file a JIRA
 for the bug, check if you can assign it to yourself and fix it independently of the feature. This helps us to
 differentiate between bug fixes and features and allows us to build stable maintenance releases.
 
 3. Write a clear commit message, with a short, descriptive title and a message that is exactly long
-enough to explain what the problem was, and how it was fixed. 
+enough to explain what the problem was and how it was fixed. 
   * The PR title should be of the form [LIVY-xxxx] Title, where LIVY-xxxx is the relevant JIRA number and Title may be
   the JIRA's title or a more specific title describing the PR itself.
   * If the pull request is still a work in progress, and so is not ready to be merged, but needs to be pushed to Github

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -62,3 +62,12 @@ template listing available configuration keys and their default values.
 be restricted to either their default values, or the values set in the Spark configuration used by Livy.
 * **log4j.properties:** configuration for Livy logging. Defines log levels and where log messages will be written to.
 The default configuration template will print log messages to stderr.
+
+### 4. Start using Livy
+
+Once the Livy server is running, you can connect to it, by default, on port 8998 (this can be changed with the 
+`livy.server.port` config option). Some examples to get started are provided [here]({{ site.baseurl }}/examples), 
+or you can check out the API documentation:
+
+* [REST API]({{ site.baseurl }}/docs/latest/rest-api.html)
+* [Programmatic API]({{ site.baseurl }}/docs/latest/programmatic-api.html)

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -65,7 +65,7 @@ The default configuration template will print log messages to stderr.
 
 ### 4. Start using Livy
 
-Once the Livy server is running, you can connect to it, by default, on port 8998 (this can be changed with the 
+Once the Livy server is running, you can connect to it on port 8998 (this can be changed with the 
 `livy.server.port` config option). Some examples to get started are provided [here]({{ site.baseurl }}/examples), 
 or you can check out the API documentation:
 


### PR DESCRIPTION
I just heard about Livy the other day when it was announced it was included with [AWS EMR 5.9.0](https://aws.amazon.com/about-aws/whats-new/2017/10/support-for-apache-livy-hue-4-0-1-and-presto-0-184-on-amazon-emr-release-5-9-0/). I was checking out the website when evaluating how we could use Livy in our workflows and noticed a couple simple improvements I could make.

This PR changes the following on the Livy website:

* Adds a "Start Using" section to getting started page - provide a stronger call to action after you've set up Livy (including what the default port is)
* Improve grammar on the Community page - noticed a couple small tweaks to make here

Hopefully it's fine to provide both of these changes in the same PR.