### PR TITLE
[LIVY-442] Remove git clone from user page

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -58,14 +58,6 @@ limitations under the License.
     </tbody>
 </table>
 
-You can also retrieve the source files from our git repository by typing:
-
-<pre>
-git clone {{site.data.project.source_repository_mirror}}
-cd {{site.data.project.github_project_name}}
-git checkout -b tags/v{{site.data.project.latest_release}} v{{site.data.project.latest_release}}
-</pre>
-
 ### Release Notes
 
 Release notes for the current and previous releases can be found in the [release history]({{ site.baseurl }}/history)

--- a/site/download.md
+++ b/site/download.md
@@ -58,7 +58,7 @@ limitations under the License.
     </tbody>
 </table>
 
-You can also retrieve the source files from our [git repository](https://github.com/apache/{{ site.data.project.incubator_name }}) by typing:
+You can also retrieve the source files from our git repository by typing:
 
 <pre>
 git clone {{site.data.project.source_repository_mirror}}


### PR DESCRIPTION
[LIVY-442](https://issues.apache.org/jira/browse/LIVY-442)

Pages meant for users shouldn't have instructions to download source code meant for developers

http://www.apache.org/dev/release-distribution#unreleased