### PR TITLE
Added missing link to 'Examples' page

### DIFF
--- a/site/docs/0.4.0-incubating/index.html
+++ b/site/docs/0.4.0-incubating/index.html
@@ -61,6 +61,9 @@
                           
                           
                           <li><a href="programmatic-api.html" target="_self">Programmatic API</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       

--- a/site/docs/0.4.0-incubating/programmatic-api.html
+++ b/site/docs/0.4.0-incubating/programmatic-api.html
@@ -61,6 +61,9 @@
                           
                           
                           <li><a href="programmatic-api.html" target="_self">Programmatic API</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       

--- a/site/docs/0.4.0-incubating/rest-api.html
+++ b/site/docs/0.4.0-incubating/rest-api.html
@@ -61,6 +61,9 @@
                           
                           
                           <li><a href="programmatic-api.html" target="_self">Programmatic API</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       

--- a/site/docs/0.5.0-incubating/index.html
+++ b/site/docs/0.5.0-incubating/index.html
@@ -67,6 +67,9 @@
                           
                           
                           <li><a href="api/scala/index.html#org.apache.livy.scalaapi.package" target="_self">Scala API Docs</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       

--- a/site/docs/0.5.0-incubating/programmatic-api.html
+++ b/site/docs/0.5.0-incubating/programmatic-api.html
@@ -67,6 +67,9 @@
                           
                           
                           <li><a href="api/scala/index.html#org.apache.livy.scalaapi.package" target="_self">Scala API Docs</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       

--- a/site/docs/0.5.0-incubating/rest-api.html
+++ b/site/docs/0.5.0-incubating/rest-api.html
@@ -67,6 +67,9 @@
                           
                           
                           <li><a href="api/scala/index.html#org.apache.livy.scalaapi.package" target="_self">Scala API Docs</a></li>
+
+
+                          <li><a href="/examples" target="_self">Examples</a></li>
                           
                       </ul>
                       


### PR DESCRIPTION
Currently, the site navigation only shows the link to the Examples page from the site's home page (in the `Documentation` dropdown). If you navigate to the REST API page or the Programmatic API page, the link is no longer there.

I've added the missing link to keep the navigation consistent with the rest of the site (and it's just annoying having to go back to the homepage to get to the examples).

I also added myself to the list of committers as I would like to start contributing to Livy and its website if acceptable.