### PR TITLE
[LIVY-462][DOCS] Minor Update to the Getting Started Page

### DIFF
--- a/site/get-started.md
+++ b/site/get-started.md
@@ -40,7 +40,7 @@ builds of Spark. To run Livy with local sessions, first export these variables:
 
 Then start the server with:
 
-`./bin/livy-server`
+`./bin/livy-server start`
 
 Livy uses the Spark configuration under `SPARK_HOME` by default. You can override the Spark configuration by setting the
 `SPARK_CONF_DIR` environment variable before starting Livy.


### PR DESCRIPTION
[LIVY-462](https://issues.apache.org/jira/browse/LIVY-462)

For the current version of Livy the `livy-server` script should be run with the `start` arg