### PR TITLE
Add a new link in third-party-projects.md

### DIFF
--- a/site/third-party-projects.md
+++ b/site/third-party-projects.md
@@ -34,3 +34,5 @@ Please open a pull request [here]({{ site.data.project.website_repository_mirror
 
 * [node-livy-client](https://www.npmjs.com/package/node-livy-client) - Livy client written in NodeJS
 
+* [spark-sql-server](https://github.com/maropu/spark-sql-server) - A Spark SQL server based on the PostgreSQL V3 protocol
+


### PR DESCRIPTION
This pr added a new link in `third-party-projects.md`. I'm working on a Spark SQL server based on the PostgreSQL V3 protocol; it uses `Livy` for managing multiple `SparkContext` (See for details: https://github.com/maropu/spark-sql-server#execution-modes)