### PR TITLE
[LIVY-1020] Missing Apache Links on Website

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 source 'https://rubygems.org'
-gem 'github-pages', '142'
+gem 'github-pages', '~> 228'
 gem 'rouge'
 gem 'jekyll-oembed', :require => 'jekyll_oembed'
+gem 'base64'
+gem 'bigdecimal'
+gem 'rexml'
+gem 'csv'
+gem 'webrick'
 # End Gemfile

--- a/site/_data/navigation.yml
+++ b/site/_data/navigation.yml
@@ -59,6 +59,7 @@ topnav:
     url: http://www.apache.org/foundation/thanks.html
   - title: Security
     url: http://www.apache.org/security/
-# TODO: Create Privacy Policy Page
-#  - title: Privacy Policy
-#    url: /privacy-policy
+  - title: Events
+    url: https://events.apache.org/
+  - title: Privacy
+    url: https://privacy.apache.org/policies/privacy-policy-public.html


### PR DESCRIPTION
This change adds missing links for Privacy and Events to the Apache navigation menu as required for graduation.
