### PR TITLE
LIVY-1020 - Add Release Process page to Community Navigation Menu

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -22,8 +22,8 @@ bundle exec jekyll clean
 bundle exec jekyll build -d _site
 COMMIT_HASH=`git rev-parse HEAD`
 cd ..
-git checkout -B asf-site apache/asf-site
-git pull --rebase
+git checkout -B asf-site apache-github/asf-site
+git pull --rebase apache-github asf-site
 rm -rf content
 mkdir content
 mv site/_site/* content
@@ -33,7 +33,7 @@ git commit -a -m "Publishing from $COMMIT_HASH"
 echo "> > >"
 echo " "
 echo "You are now on the asf-site branch"
-echo "Run git push apache asf-site to update the live site."
+echo "Run git push apache-github asf-site to update the live site."
 echo " "
 echo " "
 set +e

--- a/site/_data/navigation.yml
+++ b/site/_data/navigation.yml
@@ -39,6 +39,9 @@ topnav:
     url: /community-members
   - title: Third-Party Projects
     url: /third-party-projects
+  - title: Release Process
+    url: /release-process
+
   - title: Issue Tracker
     url: https://issues.apache.org/jira/browse/LIVY
   - title: Source Code


### PR DESCRIPTION
The release process doc was not being referenced in the site links so unless you knew it was there and manually navigated to it, it was hidden.