### PR TITLE
[LIVY-1049] Remove the '-incubating' designator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ limitations under the License.
 {% endcomment %}
 -->
 
-# Apache Livy (Incubating) Website
+# Apache Livy Website
 
-The Apache Livy (Incubating) website was forked from the
+The Apache Livy website was forked from the
 [Apache Website Template](https://github.com/apache/apache-website-template).
 
 This website is generated using [Jekyll](https://jekyllrb.com/).
@@ -68,7 +68,7 @@ This assumes an upstream name of apache and committer privileges.
 ```
 
 Within a few minutes, gitpubsub should kick in and you'll be able to see the results at
-[livy.incubator.apache.org](https://livy.incubator.apache.org/).
+[livy.apache.org](https://livy.apache.org/).
 
 ## Adding contributors
 

--- a/merge_livy_pr.py
+++ b/merge_livy_pr.py
@@ -19,13 +19,13 @@
 
 # Utility for creating well-formed pull request merges and pushing them to Apache.
 #
-# This utility assumes you already have local a incubator-livy-website git folder and that you
-# have added remotes corresponding to both (i) the github apache incubator-livy-website
+# This utility assumes you already have local a livy-website git folder and that you
+# have added remotes corresponding to both (i) the github apache livy-website
 # mirror and (ii) the apache git repo.
 #
-# 1. Adding github apache incubator-livy-website mirror remote to your local repo with name "apache-github"
+# 1. Adding github apache livy-website mirror remote to your local repo with name "apache-github"
 #    (for example) using "git remote add apache-github ...".
-# 2. Adding apache incubator-livy-website remote to your local repo with name "apache" (for example) using
+# 2. Adding apache livy-website remote to your local repo with name "apache" (for example) using
 #    "git remote add apache ..."
 # 3. Invoke this script from LIVY_WEBSITE_HOME (./merge_livy_pr.py) and follow the prompted steps.
 # 4. If you want to handle the associated JIRA, JIRA_USERNAME and JIRA_PASSWORD should be set.
@@ -47,7 +47,7 @@ try:
 except ImportError:
     JIRA_IMPORTED = False
 
-# Location of your incubator-livy-website git development area
+# Location of your livy-website git development area
 LIVY_HOME = os.environ.get("LIVY_WEBSITE_HOME", os.getcwd())
 # Remote name which points to the Gihub site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
@@ -64,8 +64,8 @@ JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")
 GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
 
 
-GITHUB_BASE = "https://github.com/apache/incubator-livy-website/pull"
-GITHUB_API_BASE = "https://api.github.com/repos/apache/incubator-livy-website"
+GITHUB_BASE = "https://github.com/apache/livy-website/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/apache/livy-website"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"
 # Prefix added to temporary branches
@@ -155,7 +155,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
     merge_message_flags += ["-m", title]
     if body is not None:
         # We remove @ symbols from the body to avoid triggering e-mails
-        # to people every time someone creates a public fork of incubator-livy.
+        # to people every time someone creates a public fork of livy.
         merge_message_flags += ["-m", body.replace("@", "")]
 
     authors = "\n".join(["Author: %s" % a for a in distinct_authors])

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -17,7 +17,7 @@ markdown: kramdown
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: ""
 
-repository: https://github.com/apache/incubator-livy-website
+repository: https://github.com/apache/livy-website
 destination: target
 exclude: [README.md,Gemfile*]
 keep_files: [".git", ".svn", "apidocs"]

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -26,42 +26,42 @@ description: A REST Service for Apache Spark
 download: download
 latest_release: 0.9.0-incubating
 
-dev_list: dev@livy.incubator.apache.org
-dev_list_subscribe: dev-subscribe@livy.incubator.apache.org
-dev_list_unsubscribe: dev-unsubscribe@livy.incubator.apache.org
+dev_list: dev@livy.apache.org
+dev_list_subscribe: dev-subscribe@livy.apache.org
+dev_list_unsubscribe: dev-unsubscribe@livy.apache.org
 dev_list_archive: http://mail-archives.apache.org/mod_mbox/livy-dev/
-dev_list_archive_mailarchive: https://www.mail-archive.com/dev@livy.incubator.apache.org/
+dev_list_archive_mailarchive: https://www.mail-archive.com/dev@livy.apache.org/
 dev_list_archive_markmail:
 
-user_list: user@livy.incubator.apache.org
-user_list_subscribe: user-subscribe@livy.incubator.apache.org
-user_list_unsubscribe: user-unsubscribe@livy.incubator.apache.org
+user_list: user@livy.apache.org
+user_list_subscribe: user-subscribe@livy.apache.org
+user_list_unsubscribe: user-unsubscribe@livy.apache.org
 user_list_archive: http://mail-archives.apache.org/mod_mbox/livy-user/
-user_list_archive_mailarchive: https://www.mail-archive.com/user@livy.incubator.apache.org/
+user_list_archive_mailarchive: https://www.mail-archive.com/user@livy.apache.org/
 user_list_archive_markmail:
 
-commits_list: commits@livy.incubator.apache.org
-commits_list_subscribe: commits-subscribe@livy.incubator.apache.org
-commits_list_unsubscribe: commits-unsubscribe@livy.incubator.apache.org
+commits_list: commits@livy.apache.org
+commits_list_subscribe: commits-subscribe@livy.apache.org
+commits_list_unsubscribe: commits-unsubscribe@livy.apache.org
 commits_list_archive: http://mail-archives.apache.org/mod_mbox/livy-commits/
-commits_list_archive_mailarchive: https://www.mail-archive.com/commits@livy.incubator.apache.org/
+commits_list_archive_mailarchive: https://www.mail-archive.com/commits@livy.apache.org/
 commits_list_archive_markmail:
 
-issues_list: issues@livy.incubator.apache.org
-issues_list_subscribe: issues-subscribe@livy.incubator.apache.org
-issues_list_unsubscribe: issues-unsubscribe@livy.incubator.apache.org
+issues_list: issues@livy.apache.org
+issues_list_subscribe: issues-subscribe@livy.apache.org
+issues_list_unsubscribe: issues-unsubscribe@livy.apache.org
 issues_list_archive: http://mail-archives.apache.org/mod_mbox/livy-issues/
-issues_list_archive_mailarchive: https://www.mail-archive.com/issues@livy.incubator.apache.org/
+issues_list_archive_mailarchive: https://www.mail-archive.com/issues@livy.apache.org/
 issues_list_archive_markmail:
 
 jira: LIVY
 
-github_project_name: incubator-livy
+github_project_name: livy
 
-source_repository: https://git-wip-us.apache.org/repos/asf/incubator-livy.git
-source_repository_mirror: https://github.com/apache/incubator-livy
+source_repository: https://git-wip-us.apache.org/repos/asf/livy.git
+source_repository_mirror: https://github.com/apache/livy
 
-website_repository: https://git-wip-us.apache.org/repos/asf/incubator-livy-website.git
-website_repository_mirror: https://github.com/apache/incubator-livy-website
+website_repository: https://git-wip-us.apache.org/repos/asf/livy-website.git
+website_repository_mirror: https://github.com/apache/livy-website
 
-podling: true
+podling: false


### PR DESCRIPTION
As Apache Livy has graduated to a Top-Level Project (TLP), this commit removes the '-incubating' suffix from all files, build configurations, documentation and metadata.

See announcement: https://news.apache.org/foundation/entry/the-apache-software-foundation-announces-new-top-level-project-4